### PR TITLE
CON-1289 : Update properties json type to camel case

### DIFF
--- a/pkg/apis/hpestorage/v1/types.go
+++ b/pkg/apis/hpestorage/v1/types.go
@@ -32,6 +32,6 @@ type HPENodeInfoSpec struct {
 	IQNs         []string `json:"iqns,omitempty"`
 	Networks     []string `json:"networks,omitempty"`
 	WWPNs        []string `json:"wwpns,omitempty"`
-	ChapUser     string   `json:"chap_user,omitempty"`
-	ChapPassword string   `json:"chap_password,omitempty"`
+	ChapUser     string   `json:"chapUser,omitempty"`
+	ChapPassword string   `json:"chapPassword,omitempty"`
 }


### PR DESCRIPTION
If the variable chapUser and chapPassword had values set in Daemonset, then the pod creation fails since the json_type for those fields are not camelcase but had underscore. To prevent that, the json_type must also be camelcase